### PR TITLE
Fix fixnum_max and fixnum_min for my Opal Bignum Implementation

### DIFF
--- a/lib/mspec/helpers/numeric.rb
+++ b/lib/mspec/helpers/numeric.rb
@@ -18,7 +18,7 @@ class Object
   # values.
   guard = SpecGuard.new
 
-  if guard.standard? or guard.implementation? :topaz or guard.implementation? :opal
+  if guard.standard? or guard.implementation? :topaz 
     if guard.wordsize? 32
       def fixnum_max()
         (2**30) - 1
@@ -35,6 +35,14 @@ class Object
       def fixnum_min()
         -(2**62)
       end
+    end
+  elsif guard.implementation? :opal
+    def fixnum_max()
+      9007199254740991
+    end
+
+    def fixnum_min()
+      -9007199254740991
     end
   elsif guard.implementation? :rubinius
     def fixnum_max()


### PR DESCRIPTION
It should use the MAX and MIN value of Javascript Numbers specified in:
http://www.ecma-international.org/ecma-262/6.0/#sec-number.max_safe_integer

