### PR TITLE
Do not use $() for portability

### DIFF
--- a/lib/mspec/helpers/ruby_exe.rb
+++ b/lib/mspec/helpers/ruby_exe.rb
@@ -149,7 +149,7 @@ class Object
           heredoc_separator << heredoc_separator
         end
 
-        body = %Q!-e "$(cat <<'#{heredoc_separator}'\n#{code}\n#{heredoc_separator}\n)"!
+        body = %Q!-e "`cat <<'#{heredoc_separator}'\n#{code}\n#{heredoc_separator}\n`"!
       else
         body = "-e #{code.inspect}"
       end


### PR DESCRIPTION
$() is now POSIX standard, however may not be supported on some
systems.

Fix #9