### PR TITLE
Fix exception at wrong option

### DIFF
--- a/lib/mspec/utils/options.rb
+++ b/lib/mspec/utils/options.rb
@@ -150,7 +150,7 @@ class MSpecOptions
         opt, arg, rest = split rest, 1
         opt = "-" + opt
         option = process argv, opt, opt, arg
-        break if option.arg?
+        break if !option or option.arg?
       end
     end
 


### PR DESCRIPTION
When an option which has no arguments is followed by wrong option,
`process` method may return `nil` and then causes `NoMethodError`.