### PR TITLE
Fix ruby executable path resolution on Windows

### DIFF
--- a/lib/mspec/helpers/ruby_exe.rb
+++ b/lib/mspec/helpers/ruby_exe.rb
@@ -108,7 +108,9 @@ class Object
       exe, *rest = cmd.split(" ")
 
       if File.file?(exe) and File.executable?(exe)
-        return [File.expand_path(exe), *rest].join(" ")
+        exe = File.expand_path(exe)
+        exe = exe.tr('/', '\\') if PlatformGuard.windows?
+        return [exe, *rest].join(" ")
       end
     end
     nil


### PR DESCRIPTION
While it's OK to use forward slashes in the executable path on Windows when invoking the executable directly, it does cause issues in some of the more complex use cases, such as when the executable path is used as part of a command pipeline, e.g.:
```
C:\Users\Administrator>echo puts "hello" | C:/Ruby/ruby-2.2.4-i386-mingw32/bin/ruby.exe
'C:' is not recognized as an internal or external command,
operable program or batch file.
```
Replacing `/` with `\` in the executable path solves this problem:
```
C:\Users\Administrator>echo puts "hello" | C:\Ruby\ruby-2.2.4-i386-mingw32\bin\ruby.exe
hello
```
Making this change fixes a number of failures running `ruby/spec` on Windows.