### PR TITLE
Lazy calling for inspect

### DIFF
--- a/lib/mspec.rb
+++ b/lib/mspec.rb
@@ -13,6 +13,8 @@ begin
   require 'pp'
 rescue LoadError
   module Kernel
-    alias pretty_inspect inspect
+    def pretty_inspect
+      inspect
+    end
   end
 end


### PR DESCRIPTION
When missing pp (like mruby), Current implementation is not readable

```rb
[:a].should == [:b]
#=> Expected #<Array:0x7fa79981f800> to equal #<Array:0x7fa79981f500>
```

Because it's calling `Kernel#inspect` instead of `Array#inspect`

I expect like this

```rb
[:a].should == [:b]
#=> Expected [:a] to equal [:b]
```