### PR TITLE
`MockIntObject#to_int`

### DIFF
--- a/lib/mspec/mocks/proxy.rb
+++ b/lib/mspec/mocks/proxy.rb
@@ -39,7 +39,7 @@ class MockIntObject
 
   def to_int
     @calls += 1
-    @value
+    @value.to_int
   end
 
   def count

--- a/spec/mocks/proxy_spec.rb
+++ b/spec/mocks/proxy_spec.rb
@@ -387,3 +387,14 @@ describe MockProxy, "#yielding?" do
     @proxy.yielding?.should be_true
   end
 end
+
+describe MockIntObject, "#to_int" do
+  before :each do
+    @int = MockIntObject.new(10)
+  end
+
+  it "returns the number if to_int is called" do
+    @int.to_int.should == 10
+    @int.count.should == [:at_least, 1]
+  end
+end

--- a/spec/mocks/proxy_spec.rb
+++ b/spec/mocks/proxy_spec.rb
@@ -397,4 +397,9 @@ describe MockIntObject, "#to_int" do
     @int.to_int.should == 10
     @int.count.should == [:at_least, 1]
   end
+
+  it "tries to convert the target to int if to_int is called" do
+    MockIntObject.new(@int).to_int.should == 10
+    @int.count.should == [:at_least, 1]
+  end
 end


### PR DESCRIPTION
When a conversion is called on the target object which responds to `to_int`, it should be called actually and check the result.