### PR TITLE
Fix multi mspec with developing ruby

### DIFF
--- a/lib/mspec/commands/mspec.rb
+++ b/lib/mspec/commands/mspec.rb
@@ -107,7 +107,7 @@ class MSpecMain < MSpecScript
       IO.popen([env, *command], "rb+")
     }
 
-    puts children.map { |child| child.gets }.uniq
+    puts children.map { |child| child.gets("").chomp }.uniq
     formatter.start
 
     until @files.empty?
@@ -144,6 +144,9 @@ class MSpecMain < MSpecScript
     argv.concat config[:flags]
     argv.concat config[:includes]
     argv.concat config[:requires]
+    if config[:multi]
+      argv << "-r#{MSPEC_HOME}/lib/mspec/utils/empty_line.rb"
+    end
     argv << "-v"
     argv << "#{MSPEC_HOME}/bin/mspec-#{ config[:command] || "run" }"
     argv.concat config[:options]

--- a/lib/mspec/utils/empty_line.rb
+++ b/lib/mspec/utils/empty_line.rb
@@ -1,0 +1,3 @@
+BEGIN {
+  puts
+}


### PR DESCRIPTION
When any commits haven't been pushed into the main repository,
`ruby -v` prints `last_commit=` line after usual description.
Also, when configured to use jemalloc, prints `malloc_conf=` line
too.

`multi_exec` assumes `ruby -v` to print the description only in
one line, it fails in the above cases.

This fixes the failure by printing an empty line at the beginning
in worker processes and the master reads them in paragraph mode.