### PR TITLE
Use `Etc.nprocessors`

### DIFF
--- a/lib/mspec/utils/script.rb
+++ b/lib/mspec/utils/script.rb
@@ -1,4 +1,5 @@
 require 'mspec/guards/guard'
+require 'etc'
 
 # MSpecScript provides a skeleton for all the MSpec runner scripts.
 
@@ -227,21 +228,7 @@ class MSpecScript
   end
 
   def cores
-    # From https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/utility/processor_counter.rb
-    if File.readable?("/proc/cpuinfo") # Linux
-      cores = File.readlines("/proc/cpuinfo").count { |line| line.start_with?('processor') }
-      raise "Could not parse /proc/cpuinfo" if cores == 0
-      cores
-    elsif File.executable?("/usr/sbin/psrinfo") # Solaris
-      File.readlines("/usr/sbin/psrinfo").grep(/on-*line/).size
-    elsif File.executable?("/usr/sbin/sysctl") # Darwin
-      Integer(`/usr/sbin/sysctl -n hw.ncpu`)
-    elsif File.executable?("/sbin/sysctl") # BSD
-      Integer(`/sbin/sysctl -n hw.ncpu`)
-    else
-      warn "Could not find number of processors"
-      1
-    end
+    Etc.nprocessors
   end
 
   def setup_env

--- a/lib/mspec/utils/script.rb
+++ b/lib/mspec/utils/script.rb
@@ -1,5 +1,4 @@
 require 'mspec/guards/guard'
-require 'etc'
 
 # MSpecScript provides a skeleton for all the MSpec runner scripts.
 
@@ -228,6 +227,7 @@ class MSpecScript
   end
 
   def cores
+    require 'etc'
     Etc.nprocessors
   end
 


### PR DESCRIPTION
`Etc.nprocessors` is portable and available on all living versions
since 2.2.