### PR TITLE
Suppress warning for mruby

### DIFF
--- a/lib/mspec/commands/mspec.rb
+++ b/lib/mspec/commands/mspec.rb
@@ -157,7 +157,7 @@ class MSpecMain < MSpecScript
       exit multi_exec(argv)
     else
       $stderr.puts "$ #{argv.join(' ')}"
-      exec *argv
+      exec(*argv)
     end
   end
 end


### PR DESCRIPTION
mspec puts warnging with this message in mruby .
`'*' interpreted as argument prefix`