### PR TITLE
Remove Ruby 2.3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ specs in a manner compatible with multiple Ruby implementations.
 
 ## Requirements
 
-MSpec requires Ruby 2.3 or more recent.
+MSpec requires Ruby 2.4 or more recent.
 
 ## Bundler
 

--- a/lib/mspec/utils/script.rb
+++ b/lib/mspec/utils/script.rb
@@ -39,8 +39,8 @@ class MSpecScript
   end
 
   def initialize
-    ruby_version_is ""..."2.3" do
-      abort "MSpec needs Ruby 2.3 or more recent"
+    ruby_version_is ""..."2.4" do
+      abort "MSpec needs Ruby 2.4 or more recent"
     end
 
     config[:formatter] = nil


### PR DESCRIPTION
ref: https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/, https://github.com/ruby/mspec/pull/40