### PR TITLE
Call `to_int` explicitly for mruby

### DIFF
--- a/lib/mspec/utils/version.rb
+++ b/lib/mspec/utils/version.rb
@@ -42,7 +42,7 @@ class SpecVersion
 
   def <=>(other)
     if other.respond_to? :to_int
-      other = Integer other
+      other = Integer(other.to_int)
     else
       other = SpecVersion.new(String(other)).to_i
     end


### PR DESCRIPTION
Hi.
I'm using mspec on mruby.

mruby's `Integer()` does not call `to_int`.
see also https://github.com/mruby/mruby/commit/afca99a40b8a3415b3a9a0e8fc41c93ddcbb11d8