### PR TITLE
Allow older rubies (with warning)

### DIFF
--- a/lib/mspec/utils/script.rb
+++ b/lib/mspec/utils/script.rb
@@ -38,9 +38,7 @@ class MSpecScript
   end
 
   def initialize
-    ruby_version_is ""..."2.5" do
-      abort "MSpec needs Ruby 2.5 or more recent"
-    end
+    check_version!
 
     config[:formatter] = nil
     config[:includes]  = []
@@ -279,5 +277,11 @@ class MSpecScript
     script.setup_env
     require 'mspec'
     script.run
+  end
+
+  private def check_version!
+    ruby_version_is ""..."2.5" do
+      warn "MSpec is supported for Ruby 2.5 and above only"
+    end
   end
 end


### PR DESCRIPTION
I use `mspec` for `backports`.

I use it to run recent specs against old rubies that have had features backported.

I am in the process of using `ruby/mspec` instead of `mspec` gem because some specs no longer run (in particular because `lambda?` helper is new, not sure if there are other reasons).

So that the specs run, I need to tell `ruby_version_is` what the actual target is. There used to be `SpecGuard.ruby_version_override=`, which as been removed. I can go around that.

Also, `mspec` refuses to run older Rubies .. This PR is a small change to allow me to run `mspec` from older versions by turning an error into a warning / or overwrite the method altogether.

I imagine that the minimum Ruby requirement is constantly being bumped to minimize support. I'm not sure it is the right approach. `mspec` aims to be a simple and minimal implementation of `rspec`-like runner so that other Ruby implementation can hope to run it. Either `mspec` runs on older rubies (and this bumping is not necessary) or it doesn't (and this may make alternate implementations harder). FWIW, current `master` appears to run (at least for my purposes) in Ruby 2.1 (in Ruby 2.0 the `private def` don't work, I don't know if there are other actual issues) Hopefully this can be the case for some years to come...

