### PR TITLE
Switch to use GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: build (${{ matrix.ruby }} / ${{ matrix.os }})
+    strategy:
+      matrix:
+        ruby: [ 3.0, 2.7, 2.6, 2.5, 2.4, head, truffleruby-20.3.0 ]
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: |
+        gem install bundler --no-document
+        bundle install
+    - name: Run test
+      run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.0, 2.7, 2.6, 2.5, 2.4, head, truffleruby-20.3.0 ]
+        ruby: [ 2.7, 2.6, 2.5, 2.4, truffleruby-20.3.0 ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-script:
-  - bundle exec rspec
-rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
-  - truffleruby


### PR DESCRIPTION
@eregon I got the migration notification from Travis CI. I want to migrate to GitHub Actions from travis-ci.com because travis-ci.com is the limitation and paid service for OSS. 

How about this migration?