### PR TITLE
Also remove comments immediately preceding old guards

### DIFF
--- a/tool/remove_old_guards.rb
+++ b/tool/remove_old_guards.rb
@@ -21,20 +21,24 @@ def remove_guards(guard, keep)
       puts file
       lines = contents.lines.to_a
       while first = lines.find_index { |line| line =~ guard }
+        comment = first
+        while comment > 0 and lines[comment-1] =~ /^(\s*)#/
+          comment -= 1
+        end
         indent = lines[first][/^(\s*)/, 1].length
         last = (first+1...lines.size).find { |i|
           space = lines[i][/^(\s*)end$/, 1] and space.length == indent
         }
         raise file unless last
         if keep
-          lines[first..last] = lines[first+1..last-1].map { |l| dedent(l) }
+          lines[comment..last] = lines[first+1..last-1].map { |l| dedent(l) }
         else
-          if first > 0 and lines[first-1] == "\n"
-            first -= 1
+          if comment > 0 and lines[comment-1] == "\n"
+            comment -= 1
           elsif lines[last+1] == "\n"
             last += 1
           end
-          lines[first..last] = []
+          lines[comment..last] = []
         end
       end
       File.binwrite file, lines.join


### PR DESCRIPTION
This makes `tool/remove_old_guards.rb` also delete comments like the ones in ruby/spec#915