### PR TITLE
Rescue File.expand_path in MSpecScript#try_load if HOME is unavailable

### DIFF
--- a/lib/mspec/utils/script.rb
+++ b/lib/mspec/utils/script.rb
@@ -84,7 +84,12 @@ class MSpecScript
 
     names.each do |name|
       config[:path].each do |dir|
-        file = File.expand_path name, dir
+        begin
+          file = File.expand_path name, dir
+        rescue ArgumentError
+          # File.expand_path can issue error e.g. if HOME is not available
+          next
+        end
         if @loaded.include?(file)
           return true
         elsif File.exist? file


### PR DESCRIPTION
mspec tries to load ~/.mspecrc, but some platforms (e.g. WASI) doesn't have HOME concept, so `~` cannot be expanded and `File.expand_path` can fail.

Cherry-pick https://github.com/ruby/ruby/pull/5566/