### PR TITLE
Added dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
the dependabot of "github-actions" will create the auto-update PRs for actions like https://github.com/ruby/bigdecimal/pull/242

Especially, `actions/checkout@v2` warns the old version of nodejs. We ignore them automatically.