### PR TITLE
Add script to check require_relative for spec_helper

### DIFF
--- a/tool/check_require_spec_helper.rb
+++ b/tool/check_require_spec_helper.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+# This script is used to check that each *_spec.rb file has
+# a relative_require for spec_helper which should live higher
+# up in the ruby/spec repo directory tree.
+#
+# Prints errors to $stderr and returns a non-zero exit code when
+# errors are found.
+#
+# Related to https://github.com/ruby/spec/pull/992
+
+def check_file(fn)
+  File.foreach(fn) do |line|
+    return $1 if line =~ /^\s*require_relative\s*['"](.*spec_helper)['"]/
+  end
+  nil
+end
+
+rootdir = ARGV[0] || "."
+fglob = File.join(rootdir, "**", "*_spec.rb")
+specfiles = Dir.glob(fglob)
+raise "No spec files found in #{fglob.inspect}. Give an argument to specify the root-directory of ruby/spec" if specfiles.empty?
+
+errors = 0
+specfiles.sort.each do |fn|
+  result = check_file(fn)
+  if result.nil?
+    warn "Missing require_relative for *spec_helper for file: #{fn}"
+    errors += 1
+  end
+end
+
+puts "# Found #{errors} files with require_relative spec_helper issues."
+exit 1 if errors > 0


### PR DESCRIPTION
Adds a script that can be used to check that `require_relative` for spec_helper is in each *_spec.rb file.  Having the require in each file is helpful so each spec can be easily run standalone with ruby from the command line. 

This is in response to https://github.com/ruby/spec/pull/992 per @eregon 's request.

Note that this is a simple check for "require_relative .*spec_helper" in each *_spec.rb file and it would incorrectly fail the case where a *_spec.rb file required another file which required spec_helper.
