### PR TITLE
Use File.readlines instead of IO.readlines

### DIFF
--- a/lib/mspec/runner/mspec.rb
+++ b/lib/mspec/runner/mspec.rb
@@ -396,7 +396,7 @@ module MSpec
     desc = tag.escape(tag.description)
     file = tags_file
     if File.exist? file
-      lines = IO.readlines(file)
+      lines = File.readlines(file)
       File.open(file, "w:utf-8") do |f|
         lines.each do |line|
           line = line.chomp


### PR DESCRIPTION
suppress https://github.com/ruby/ruby/security/code-scanning/792 warning.