### PR TITLE
Don't load myhostname NSS module in leakchecker

### DIFF
--- a/lib/mspec/runner/actions/leakchecker.rb
+++ b/lib/mspec/runner/actions/leakchecker.rb
@@ -358,7 +358,7 @@ class LeakCheckerAction
     nss_configure_lookup.call 'passwd', 'files'
     nss_configure_lookup.call 'shadow', 'files'
     nss_configure_lookup.call 'group', 'files'
-    nss_configure_lookup.call 'hosts', 'files dns myhostname'
+    nss_configure_lookup.call 'hosts', 'files dns'
     nss_configure_lookup.call 'services', 'files'
     nss_configure_lookup.call 'netgroup', 'files'
     nss_configure_lookup.call 'automount', 'files'


### PR DESCRIPTION
I thought this was a part of glibc, but it's not - it's actually a part of systemd-hostnamed. We definitely don't want this, because it's 1) not guaranteed to be on all systems, and 2) will make a dbus connection which is exactly what we don't want.