### PR TITLE
Fix memory leak in mock

### DIFF
--- a/lib/mspec/mocks/mock.rb
+++ b/lib/mspec/mocks/mock.rb
@@ -19,7 +19,7 @@ module Mock
   end
 
   def self.replaced_name(key)
-    :"__mspec_#{key.first}_#{key.last}__"
+    :"__mspec_#{key.last}__"
   end
 
   def self.replaced_key(obj, sym)

--- a/lib/mspec/mocks/mock.rb
+++ b/lib/mspec/mocks/mock.rb
@@ -26,12 +26,8 @@ module Mock
     [replaced_name(obj, sym), sym]
   end
 
-  def self.has_key?(keys, sym)
-    !!keys.find { |k| k.first == sym }
-  end
-
-  def self.replaced?(sym)
-    has_key?(mocks.keys, sym) or has_key?(stubs.keys, sym)
+  def self.replaced?(key)
+    mocks.include?(key) or stubs.include?(key)
   end
 
   def self.clear_replaced(key)
@@ -40,8 +36,9 @@ module Mock
   end
 
   def self.mock_respond_to?(obj, sym, include_private = false)
-    name = replaced_name(obj, :respond_to?)
-    if replaced? name
+    key = replaced_key(obj, :respond_to?)
+    if replaced? key
+      name = replaced_name(obj, :respond_to?)
       obj.__send__ name, sym, include_private
     else
       obj.respond_to? sym, include_private
@@ -59,7 +56,7 @@ module Mock
       return
     end
 
-    if (sym == :respond_to? or mock_respond_to?(obj, sym, true)) and !replaced?(key.first)
+    if (sym == :respond_to? or mock_respond_to?(obj, sym, true)) and !replaced?(key)
       meta.__send__ :alias_method, key.first, sym
     end
 

--- a/lib/mspec/mocks/mock.rb
+++ b/lib/mspec/mocks/mock.rb
@@ -18,12 +18,12 @@ module Mock
     @stubs ||= Hash.new { |h,k| h[k] = [] }
   end
 
-  def self.replaced_name(obj, sym)
-    :"__mspec_#{obj.__id__}_#{sym}__"
+  def self.replaced_name(key)
+    :"__mspec_#{key.first}_#{key.last}__"
   end
 
   def self.replaced_key(obj, sym)
-    [replaced_name(obj, sym), sym]
+    [obj.__id__, sym]
   end
 
   def self.replaced?(key)
@@ -38,7 +38,7 @@ module Mock
   def self.mock_respond_to?(obj, sym, include_private = false)
     key = replaced_key(obj, :respond_to?)
     if replaced? key
-      name = replaced_name(obj, :respond_to?)
+      name = replaced_name(key)
       obj.__send__ name, sym, include_private
     else
       obj.respond_to? sym, include_private
@@ -57,7 +57,7 @@ module Mock
     end
 
     if (sym == :respond_to? or mock_respond_to?(obj, sym, true)) and !replaced?(key)
-      meta.__send__ :alias_method, key.first, sym
+      meta.__send__ :alias_method, replaced_name(key), sym
     end
 
     suppress_warning {
@@ -188,7 +188,7 @@ module Mock
         next
       end
 
-      replaced = key.first
+      replaced = replaced_name(key)
       sym = key.last
       meta = obj.singleton_class
 

--- a/spec/mocks/mock_spec.rb
+++ b/spec/mocks/mock_spec.rb
@@ -22,7 +22,7 @@ end
 RSpec.describe Mock, ".replaced_name" do
   it "returns the name for a method that is being replaced by a mock method" do
     m = double('a fake id')
-    expect(Mock.replaced_name(Mock.replaced_key(m, :method_call))).to eq(:"__mspec_#{m.object_id}_method_call__")
+    expect(Mock.replaced_name(Mock.replaced_key(m, :method_call))).to eq(:"__mspec_method_call__")
   end
 end
 

--- a/spec/mocks/mock_spec.rb
+++ b/spec/mocks/mock_spec.rb
@@ -22,14 +22,14 @@ end
 RSpec.describe Mock, ".replaced_name" do
   it "returns the name for a method that is being replaced by a mock method" do
     m = double('a fake id')
-    expect(Mock.replaced_name(m, :method_call)).to eq(:"__mspec_#{m.object_id}_method_call__")
+    expect(Mock.replaced_name(Mock.replaced_key(m, :method_call))).to eq(:"__mspec_#{m.object_id}_method_call__")
   end
 end
 
 RSpec.describe Mock, ".replaced_key" do
   it "returns a key used internally by Mock" do
     m = double('a fake id')
-    expect(Mock.replaced_key(m, :method_call)).to eq([:"__mspec_#{m.object_id}_method_call__", :method_call])
+    expect(Mock.replaced_key(m, :method_call)).to eq([m.object_id, :method_call])
   end
 end
 
@@ -197,11 +197,11 @@ RSpec.describe Mock, ".install_method" do
 
     Mock.install_method @mock, :method_call
     expect(@mock).to respond_to(:method_call)
-    expect(@mock).not_to respond_to(Mock.replaced_name(@mock, :method_call))
+    expect(@mock).not_to respond_to(Mock.replaced_name(Mock.replaced_key(@mock, :method_call)))
 
     Mock.install_method @mock, :method_call, :stub
     expect(@mock).to respond_to(:method_call)
-    expect(@mock).not_to respond_to(Mock.replaced_name(@mock, :method_call))
+    expect(@mock).not_to respond_to(Mock.replaced_name(Mock.replaced_key(@mock, :method_call)))
   end
 end
 
@@ -493,7 +493,7 @@ RSpec.describe Mock, ".cleanup" do
   it "removes the replaced method if the mock method overrides an existing method" do
     def @mock.already_here() :hey end
     expect(@mock).to respond_to(:already_here)
-    replaced_name = Mock.replaced_name(@mock, :already_here)
+    replaced_name = Mock.replaced_name(Mock.replaced_key(@mock, :already_here))
     Mock.install_method @mock, :already_here
     expect(@mock).to respond_to(replaced_name)
 

--- a/spec/mocks/mock_spec.rb
+++ b/spec/mocks/mock_spec.rb
@@ -42,16 +42,16 @@ RSpec.describe Mock, ".replaced?" do
 
   it "returns true if a method has been stubbed on an object" do
     Mock.install_method @mock, :method_call
-    expect(Mock.replaced?(Mock.replaced_name(@mock, :method_call))).to be_truthy
+    expect(Mock.replaced?(Mock.replaced_key(@mock, :method_call))).to be_truthy
   end
 
   it "returns true if a method has been mocked on an object" do
     Mock.install_method @mock, :method_call, :stub
-    expect(Mock.replaced?(Mock.replaced_name(@mock, :method_call))).to be_truthy
+    expect(Mock.replaced?(Mock.replaced_key(@mock, :method_call))).to be_truthy
   end
 
   it "returns false if a method has not been stubbed or mocked" do
-    expect(Mock.replaced?(Mock.replaced_name(@mock, :method_call))).to be_falsey
+    expect(Mock.replaced?(Mock.replaced_key(@mock, :method_call))).to be_falsey
   end
 end
 
@@ -521,10 +521,9 @@ RSpec.describe Mock, ".cleanup" do
     replaced_key = Mock.replaced_key(@mock, :method_call)
     expect(Mock).to receive(:clear_replaced).with(replaced_key)
 
-    replaced_name = Mock.replaced_name(@mock, :method_call)
-    expect(Mock.replaced?(replaced_name)).to be_truthy
+    expect(Mock.replaced?(replaced_key)).to be_truthy
 
     Mock.cleanup
-    expect(Mock.replaced?(replaced_name)).to be_falsey
+    expect(Mock.replaced?(replaced_key)).to be_falsey
   end
 end


### PR DESCRIPTION
As discussed in https://github.com/ruby/mspec/issues/67.

The commits are incremental and coherent changes, so going commit by commit may be the easiest way to review.

`rspec` on this repo, and the `mspec` on ruby-spec are both passing with these changes.

To see the impact easily, edit `ruby-spec/spec/core/hash/compare_by_identity_spec.rb` to only leave the spec `uses #equal? semantics, but doesn't actually call #equal? to determine identity`. (line 50)

Then run `../mspec/bin/mspec --repeat 1000000 core/hash/compare_by_identity_spec.rb`.

It should be easy to see the memory that just keeps going up quickly (before this change) using `top` or similar monitoring tool.
