### PR TITLE
tmp: accept frozen strings

### DIFF
--- a/lib/mspec/helpers/tmp.rb
+++ b/lib/mspec/helpers/tmp.rb
@@ -12,7 +12,7 @@ else
 end
 SPEC_TEMP_DIR = spec_temp_dir
 
-SPEC_TEMP_UNIQUIFIER = "0"
+SPEC_TEMP_UNIQUIFIER = +"0"
 
 at_exit do
   begin
@@ -41,6 +41,7 @@ def tmp(name, uniquify = true)
   if uniquify and !name.empty?
     slash = name.rindex "/"
     index = slash ? slash + 1 : 0
+    name = +name
     name.insert index, "#{SPEC_TEMP_UNIQUIFIER.succ!}-"
   end
 


### PR DESCRIPTION
Ref: https://github.com/ruby/ruby/pull/10235

As discussed upstream, the mutability is only used in one spec, `path.rb`:

```ruby
    @name = +"file_to_path"
    @path = tmp(@name)
```

For all the others it doesn't matter if the argument is mutated or not.

cc @eregon 