### PR TITLE
Update load path modification in mspec-run.rb

### DIFF
--- a/lib/mspec/commands/mkspec.rb
+++ b/lib/mspec/commands/mkspec.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 require 'rbconfig'
 require 'mspec/version'
 require 'mspec/utils/options'

--- a/lib/mspec/commands/mspec-ci.rb
+++ b/lib/mspec/commands/mspec-ci.rb
@@ -1,7 +1,3 @@
-#!/usr/bin/env ruby
-
-$:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
-
 require 'mspec/version'
 require 'mspec/utils/options'
 require 'mspec/utils/script'

--- a/lib/mspec/commands/mspec-run.rb
+++ b/lib/mspec/commands/mspec-run.rb
@@ -1,7 +1,3 @@
-#!/usr/bin/env ruby
-
-$:.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
-
 require 'mspec/version'
 require 'mspec/utils/options'
 require 'mspec/utils/script'

--- a/lib/mspec/commands/mspec-tag.rb
+++ b/lib/mspec/commands/mspec-tag.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 require 'mspec/version'
 require 'mspec/utils/options'
 require 'mspec/utils/script'

--- a/lib/mspec/commands/mspec.rb
+++ b/lib/mspec/commands/mspec.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 require 'mspec/version'
 require 'mspec/utils/options'
 require 'mspec/utils/script'


### PR DESCRIPTION
This file has probably been moved at some point, the old version would to `lib/mspec/lib` which does not exist. The new version is inspired by the syntax of `bin/mspec-run` to keep things consistent.

Since the usual way to call this script is via `bin/mspec-run`, and that sets up your load path, an alternative way to fix this would be to simply remove this load path update in this file.