### PR TITLE
Add repeat option to ci command

### DIFF
--- a/lib/mspec/commands/mspec-ci.rb
+++ b/lib/mspec/commands/mspec-ci.rb
@@ -18,6 +18,7 @@ class MSpecCI < MSpecScript
     options.chdir
     options.prefix
     options.configure { |f| load f }
+    options.repeat
     options.pretend
     options.interrupt
     options.timeout

--- a/spec/commands/mspec_ci_spec.rb
+++ b/spec/commands/mspec_ci_spec.rb
@@ -78,6 +78,11 @@ RSpec.describe MSpecCI, "#options" do
     @script.options []
   end
 
+  it "enables the repeat option" do
+    expect(@options).to receive(:repeat)
+    @script.options @argv
+  end
+
   it "calls #custom_options" do
     expect(@script).to receive(:custom_options).with(@options)
     @script.options []

--- a/spec/commands/mspec_run_spec.rb
+++ b/spec/commands/mspec_run_spec.rb
@@ -105,6 +105,11 @@ RSpec.describe MSpecRun, "#options" do
     @script.options @argv
   end
 
+  it "enables the repeat option" do
+    expect(@options).to receive(:repeat)
+    @script.options @argv
+  end
+
   it "exits if there are no files to process and './spec' is not a directory" do
     expect(File).to receive(:directory?).with("./spec").and_return(false)
     expect(@options).to receive(:parse).and_return([])


### PR DESCRIPTION
The repeat option was only supported by the run command, but for convenience this adds it to the ci command. Specs are also added to ensure the option is available for both commands.

Fixes #74